### PR TITLE
added fix for all bound events responding to all instances

### DIFF
--- a/animation.js
+++ b/animation.js
@@ -67,12 +67,13 @@ var Animation = function(options) {
   this.elapsed = 0
   this.duration = this.config.duration
   this.kill = false
+
+  EventMixin.call(this)
+
   return this
 }
 
 var proto = Animation.prototype
-
-EventMixin.call(proto)
 
 proto.eachAnims = function(fn) {
   for( var i in this.animations )


### PR DESCRIPTION
Due to the way the events class was being mixed-in directly onto the prototype, every instance of the Animation class shared the same event handlers. In other words, if you have 50 instances of the `Animation` class in your app, and bind a handler to `frame` on each, calling `animateTo` on a single instance would fire all 50 event handlers. This mixes-in the `Events` class in the `Animation` constructor, giving each instance a separate `handlers` array.

Signed-off-by: Darcy Adams darcy.adams@wellogic.com
